### PR TITLE
nd rotations now accept non-orthogonal vectors

### DIFF
--- a/mgen/rotation_matrix_nd.py
+++ b/mgen/rotation_matrix_nd.py
@@ -7,7 +7,7 @@ import numpy as np
 def rotation_from_angle_and_plane(angle, vector1, vector2, abs_tolerance=1e-10):
     '''
     generates an nxn rotation matrix from a given angle and
-    a plane spanned by two given orthogonal vectors of length n:
+    a plane spanned by two given vectors of length n:
     https://de.wikipedia.org/wiki/Drehmatrix#Drehmatrizen_des_Raumes_%7F'%22%60UNIQ--postMath-0000003B-QINU%60%22'%7F
 
     The formula used is
@@ -29,18 +29,12 @@ def rotation_from_angle_and_plane(angle, vector1, vector2, abs_tolerance=1e-10):
     :param vector2: the other of the two vectors that span the plane in which to rotate
                     (no normalisation required)
     :type vector2: array like
-    :param abs_tolerance: The absolute tolerance to use when checking if vectors are orthogonal or have length zero.
-                          Default is 1e-10, but this might be inadequate for your application.
+    :param abs_tolerance: The absolute tolerance to use when checking if vectors have length 0 or are parallel.
     :type abs_tolerance: float
-
-    .. warning:: Make sure that the two given vectors are orthogonal to each other.
 
     :returns: the rotation matrix
     :rtype: an nxn :any:`numpy.ndarray`
     '''
-    if len(vector1) != len(vector2):
-        raise ValueError(
-            'Given vectors must have the same length but are: {}, {}'.format(len(vector1), len(vector2)))
 
     vector1 = np.asarray(vector1, dtype=np.float)
     vector2 = np.asarray(vector2, dtype=np.float)
@@ -55,17 +49,31 @@ def rotation_from_angle_and_plane(angle, vector1, vector2, abs_tolerance=1e-10):
         raise ValueError(
             'Given vector2 must have norm greater than zero within given numerical tolerance: {:.0e}'.format(abs_tolerance))
 
-    vector1 /= vector1_length
     vector2 /= vector2_length
+    dot_value = np.dot(vector1, vector2)
 
-    if not math.isclose(vector1.dot(vector2), 0, abs_tol=abs_tolerance):
+    if abs(dot_value / vector1_length ) > 1 - abs_tolerance:
         raise ValueError(
-            'Given vectors are not orthogonal for given numerical tolerance: {:.0e}'.format(abs_tolerance))
+            'Given vectors are parallel within the given tolerance: {:.0e}'.format(abs_tolerance))
+
+    if abs(dot_value / vector1_length ) > abs_tolerance:
+        vector1 = vector1 - dot_value * vector2
+        vector1 /= np.linalg.norm(vector1)
+    else:
+        vector1 /= vector1_length
+
+
+    vectors = np.vstack([vector1, vector2]).T
+    vector1, vector2 = np.linalg.qr(vectors)[0].T
 
     V = np.outer(vector1, vector1) + np.outer(vector2, vector2)
     W = np.outer(vector1, vector2) - np.outer(vector2, vector1)
 
     return np.eye(len(vector1)) + (math.cos(angle) - 1)*V - math.sin(angle)*W
+
+
+
+
 
 def random_matrix(n):
     '''

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -136,6 +136,9 @@ class TestRotations(TestCase):
             is_close(rotation_around_x(rand1), rotation_from_angle_and_plane(rand1, (0,1,0), (0,0,1)))
             is_close(rotation_around_y(rand1), rotation_from_angle_and_plane(rand1, (0,0,1), (1,0,0)))
 
+            # Test non orthogonal vectors
+            is_close(rotation_around_x(rand1), rotation_from_angle_and_plane(rand1, (0, 1, 1), (0, 1, 2)))
+
             # Test generic properties of higher dimensional rotations
 
             # create two perpendicular random vectors
@@ -151,7 +154,7 @@ class TestRotations(TestCase):
             is_close(m.dot(m.T), np.eye(dimension))
             self.assertAlmostEqual(np.linalg.det(m), 1.0)
             is_close(m, m_inv.T)
-            
+
         with self.assertRaises(ValueError):
             rotation_from_angle_and_plane(0., (1,0,0), (0,1,0,0))
         with self.assertRaises(ValueError):
@@ -162,7 +165,7 @@ class TestRotations(TestCase):
             rotation_from_angle_and_plane(0., (0,0), (1,0))
         with self.assertRaises(ValueError):
             rotation_from_angle_and_plane(0., (1,0), (0,0))
-            
+
     def test_random_matrix(self):
         for x in range(2,7):
             vecx = np.zeros(x, dtype=np.float64)


### PR DESCRIPTION
The nd-rotation function now accepts non-orthogonal vectors and orthogonalizes if necessary.